### PR TITLE
refactor: Improve select existing file message

### DIFF
--- a/autoload/lh/alternate.vim
+++ b/autoload/lh/alternate.vim
@@ -277,10 +277,11 @@ function! lh#alternate#_jump(cmd, ...) abort
     else
       if !empty(files.existing)
         let lFiles = files.existing
+        let selected_file = lh#path#select_one(lFiles, "Select existing file to switch to:")
       else
         let lFiles = files.theorical
+        let selected_file = lh#path#select_one(lFiles, "What should be the name of the new file?")
       endif
-      let selected_file = lh#path#select_one(lFiles, "What should be the name of the new file?")
     endif
   endif
 


### PR DESCRIPTION
Improve the message used to query the user for the file to switch when
multiple files already exist. The current message makes it appear the
tool has not found the existing alternates and is going to create a new
file.